### PR TITLE
fix: fuse_snapshot outputs incorrect format version

### DIFF
--- a/src/query/storages/fuse/src/table_functions/fuse_snapshots/fuse_snapshot.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_snapshots/fuse_snapshot.rs
@@ -125,7 +125,7 @@ impl<'a> FuseSnapshot<'a> {
                 None => (None, 0),
             };
             prev_snapshot_ids.push(id);
-            format_versions.push(s.format_version);
+            format_versions.push(current_snapshot_version);
             segment_count.push(s.segment_count);
             block_count.push(s.block_count);
             row_count.push(s.row_count);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

with this patch, `fuse_snapshot' now outputs the correct snapshot format versions

~~~
mysql> select * from fuse_snapshot('default', 't');
+----------------------------------+------------------------------------------------------+----------------+----------------------------------+---------------+-------------+-----------+--------------------+------------------+------------+----------------------------+
| snapshot_id                      | snapshot_location                                    | format_version | previous_snapshot_id             | segment_count | block_count | row_count | bytes_uncompressed | bytes_compressed | index_size | timestamp                  |
+----------------------------------+------------------------------------------------------+----------------+----------------------------------+---------------+-------------+-----------+--------------------+------------------+------------+----------------------------+
| ab975e8bd0de4f6795a9eff743310431 | 1/24/_ss/ab975e8bd0de4f6795a9eff743310431_v3.bincode |              3 | 58987d040eb647bca0bc25cec00918bf |             5 |           5 |         5 |                 20 |              960 |       1380 | 2023-04-19 03:41:11.569619 |
| 58987d040eb647bca0bc25cec00918bf | 1/24/_ss/58987d040eb647bca0bc25cec00918bf_v2.json    |              2 | bc79a66ca7f4416189a1d205b28de6f4 |             4 |           4 |         4 |                 16 |              768 |       1104 | 2023-04-19 01:51:31.132242 |
| bc79a66ca7f4416189a1d205b28de6f4 | 1/24/_ss/bc79a66ca7f4416189a1d205b28de6f4_v2.json    |              2 | cebc15d4ae434216920eeffcaff2fd58 |             3 |           3 |         3 |                 12 |              576 |        828 | 2023-04-19 01:51:28.736611 |
| cebc15d4ae434216920eeffcaff2fd58 | 1/24/_ss/cebc15d4ae434216920eeffcaff2fd58_v2.json    |              2 | 4ea394d148564526b79aa4028efd70d1 |             2 |           2 |         2 |                  8 |              384 |        552 | 2023-04-19 01:51:26.920498 |
| 4ea394d148564526b79aa4028efd70d1 | 1/24/_ss/4ea394d148564526b79aa4028efd70d1_v2.json    |              2 | NULL                             |             1 |           1 |         1 |                  4 |              192 |        276 | 2023-04-19 01:51:23.454906 |
+----------------------------------+------------------------------------------------------+----------------+----------------------------------+---------------+-------------+-----------+--------------------+------------------+------------+----------------------------+
~~~

Closes #issue
