### PR TITLE
Fix fuse snapshot version

### DIFF
--- a/src/query/service/tests/it/storages/fuse/operations/gc.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/gc.rs
@@ -93,11 +93,7 @@ async fn test_fuse_purge_normal_orphan_snapshot() -> Result<()> {
         // that the timestamp of snapshot returned is larger than `current_snapshot`'s.
         let orphan_snapshot = TableSnapshot::from_previous(current_snapshot.as_ref());
         orphan_snapshot
-            .write_meta_data(
-                &operator,
-                &orphan_snapshot_location,
-                orphan_snapshot.to_bytes()?,
-            )
+            .write_meta(&operator, &orphan_snapshot_location)
             .await?;
     }
 
@@ -275,7 +271,7 @@ mod utils {
         }
 
         new_snapshot
-            .write_meta_data(&operator, &new_snapshot_location, new_snapshot.to_bytes()?)
+            .write_meta(&operator, &new_snapshot_location)
             .await?;
 
         Ok(new_snapshot_location)

--- a/src/query/service/tests/it/storages/fuse/operations/navigate.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/navigate.rs
@@ -92,7 +92,7 @@ async fn test_fuse_navigate() -> Result<()> {
 
     // 4. navigate to the first snapshot
     // history is order by timestamp DESC
-    let latest = &snapshots[0];
+    let (latest, _ver) = &snapshots[0];
     let instant = latest
         .timestamp
         .unwrap()
@@ -104,7 +104,7 @@ async fn test_fuse_navigate() -> Result<()> {
     assert_eq!(first_snapshot, tbl.snapshot_loc().await?.unwrap());
 
     // 4. navigate beyond the first snapshot
-    let first_insertion = &snapshots[1];
+    let (first_insertion, _ver) = &snapshots[1];
     let instant = first_insertion
         .timestamp
         .unwrap()

--- a/src/query/storages/common/table-meta/src/meta/format.rs
+++ b/src/query/storages/common/table-meta/src/meta/format.rs
@@ -158,7 +158,7 @@ pub fn encode<T: Serialize>(encoding: &Encoding, data: &T) -> Result<Vec<u8>> {
     }
 }
 
-pub fn decode<'a, T: Deserialize<'a>>(encoding: &Encoding, data: &'a Vec<u8>) -> Result<T> {
+pub fn decode<'a, T: Deserialize<'a>>(encoding: &Encoding, data: &'a [u8]) -> Result<T> {
     match encoding {
         Encoding::Bincode => {
             Ok(bincode::deserialize(data).map_err(|e| Error::new(ErrorKind::InvalidData, e))?)

--- a/src/query/storages/common/table-meta/src/meta/v3/mod.rs
+++ b/src/query/storages/common/table-meta/src/meta/v3/mod.rs
@@ -1,4 +1,4 @@
-//  Copyright 2021 Datafuse Labs.
+//  Copyright 2023 Datafuse Labs.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/src/query/storages/common/table-meta/src/meta/v3/segment.rs
+++ b/src/query/storages/common/table-meta/src/meta/v3/segment.rs
@@ -1,4 +1,4 @@
-//  Copyright 2021 Datafuse Labs.
+//  Copyright 2023 Datafuse Labs.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/src/query/storages/common/table-meta/src/meta/v3/snapshot.rs
+++ b/src/query/storages/common/table-meta/src/meta/v3/snapshot.rs
@@ -114,10 +114,6 @@ impl TableSnapshot {
         )
     }
 
-    pub fn format_version(&self) -> u64 {
-        self.format_version
-    }
-
     /// Serializes the struct to a byte vector.
     ///
     /// The byte vector contains the format version, encoding, compression, and compressed data. The encoding
@@ -191,7 +187,7 @@ pub struct TableSnapshotLite {
 impl From<&TableSnapshot> for TableSnapshotLite {
     fn from(value: &TableSnapshot) -> Self {
         TableSnapshotLite {
-            format_version: value.format_version(),
+            format_version: value.format_version,
             snapshot_id: value.snapshot_id,
             timestamp: value.timestamp,
             prev_snapshot_id: value.prev_snapshot_id,

--- a/src/query/storages/common/table-meta/src/meta/v3/snapshot.rs
+++ b/src/query/storages/common/table-meta/src/meta/v3/snapshot.rs
@@ -1,4 +1,4 @@
-//  Copyright 2022 Datafuse Labs.
+//  Copyright 2023 Datafuse Labs.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/src/query/storages/fuse/src/io/snapshots.rs
+++ b/src/query/storages/fuse/src/io/snapshots.rs
@@ -198,7 +198,7 @@ impl SnapshotsIO {
         let format_version = TableMetaLocationGenerator::snapshot_version(root_snapshot.as_str());
         let lite_snapshot_stream = table_snapshot_reader
             .snapshot_history(root_snapshot, format_version, location_generator)
-            .map_ok(|snapshot| TableSnapshotLite::from(snapshot.as_ref()));
+            .map_ok(|(snapshot, _)| TableSnapshotLite::from(snapshot.as_ref()));
         if let Some(l) = limit {
             lite_snapshot_stream.take(l).try_collect::<Vec<_>>().await
         } else {

--- a/src/query/storages/fuse/src/io/write/meta_writer.rs
+++ b/src/query/storages/fuse/src/io/write/meta_writer.rs
@@ -16,40 +16,24 @@ use std::sync::Arc;
 
 use common_exception::Result;
 use opendal::Operator;
-use serde::Serialize;
 use storages_common_cache::CacheAccessor;
 use storages_common_cache_manager::CachedObject;
+use storages_common_table_meta::meta::SegmentInfo;
+use storages_common_table_meta::meta::TableSnapshot;
+use storages_common_table_meta::meta::TableSnapshotStatistics;
 
 #[async_trait::async_trait]
 pub trait MetaWriter<T> {
     async fn write_meta(&self, data_accessor: &Operator, location: &str) -> Result<()>;
-
-    async fn write_meta_data(
-        &self,
-        data_accessor: &Operator,
-        location: &str,
-        bs: Vec<u8>,
-    ) -> Result<()>;
 }
 
 #[async_trait::async_trait]
 impl<T> MetaWriter<T> for T
-where T: Serialize + Sync + Send
+where T: Marshal + Sync + Send
 {
     #[async_backtrace::framed]
     async fn write_meta(&self, data_accessor: &Operator, location: &str) -> Result<()> {
-        write_to_storage(data_accessor, location, &self).await?;
-        Ok(())
-    }
-
-    #[async_backtrace::framed]
-    async fn write_meta_data(
-        &self,
-        data_accessor: &Operator,
-        location: &str,
-        bs: Vec<u8>,
-    ) -> Result<()> {
-        data_accessor.write(location, bs).await?;
+        data_accessor.write(location, self.marshal()?).await?;
         Ok(())
     }
 }
@@ -58,20 +42,13 @@ where T: Serialize + Sync + Send
 pub trait CachedMetaWriter<T> {
     async fn write_meta_through_cache(self, data_accessor: &Operator, location: &str)
     -> Result<()>;
-
-    async fn write_meta_data_through_cache(
-        self,
-        data_accessor: &Operator,
-        location: &str,
-        bs: Vec<u8>,
-    ) -> Result<()>;
 }
 
 #[async_trait::async_trait]
 impl<T, C> CachedMetaWriter<T> for T
 where
     T: CachedObject<T, Cache = C> + Send + Sync,
-    T: Serialize,
+    T: Marshal,
     C: CacheAccessor<String, T>,
 {
     #[async_backtrace::framed]
@@ -80,21 +57,7 @@ where
         data_accessor: &Operator,
         location: &str,
     ) -> Result<()> {
-        write_to_storage(data_accessor, location, &self).await?;
-        if let Some(cache) = T::cache() {
-            cache.put(location.to_owned(), Arc::new(self))
-        }
-        Ok(())
-    }
-
-    #[async_backtrace::framed]
-    async fn write_meta_data_through_cache(
-        self,
-        data_accessor: &Operator,
-        location: &str,
-        bs: Vec<u8>,
-    ) -> Result<()> {
-        data_accessor.write(location, bs).await?;
+        data_accessor.write(location, self.marshal()?).await?;
         if let Some(cache) = T::cache() {
             cache.put(location.to_owned(), Arc::new(self))
         }
@@ -102,22 +65,25 @@ where
     }
 }
 
-async fn write_to_storage<T>(data_accessor: &Operator, location: &str, meta: &T) -> Result<()>
-where T: Serialize {
-    let bs = serde_json::to_vec(&meta)?;
-    data_accessor.write(location, bs).await?;
-
-    Ok(())
+trait Marshal {
+    fn marshal(&self) -> Result<Vec<u8>>;
 }
 
-// TODO batch write
-// async fn batch_write_to_storage<T>(
-//    data_accessor: &Operator,
-//    location: &str,
-//    meta: &[&T],
-//) -> Result<()>
-// where
-//    T: Serialize,
-//{
-//    todo!()
-//}
+impl Marshal for SegmentInfo {
+    fn marshal(&self) -> Result<Vec<u8>> {
+        self.to_bytes()
+    }
+}
+
+impl Marshal for TableSnapshot {
+    fn marshal(&self) -> Result<Vec<u8>> {
+        self.to_bytes()
+    }
+}
+
+impl Marshal for TableSnapshotStatistics {
+    fn marshal(&self) -> Result<Vec<u8>> {
+        let bytes = serde_json::to_vec(self)?;
+        Ok(bytes)
+    }
+}

--- a/src/query/storages/fuse/src/io/write/segment_writer.rs
+++ b/src/query/storages/fuse/src/io/write/segment_writer.rs
@@ -42,9 +42,8 @@ impl<'a> SegmentWriter<'a> {
     #[async_backtrace::framed]
     pub async fn write_segment(&self, segment: SegmentInfo) -> Result<Location> {
         let location = self.generate_location();
-        let bs = segment.to_bytes()?;
         segment
-            .write_meta_data_through_cache(self.data_accessor, &location.0, bs)
+            .write_meta_through_cache(self.data_accessor, &location.0)
             .await?;
         Ok(location)
     }
@@ -53,7 +52,7 @@ impl<'a> SegmentWriter<'a> {
     pub async fn write_segment_no_cache(&self, segment: &SegmentInfo) -> Result<Location> {
         let location = self.generate_location();
         segment
-            .write_meta_data(self.data_accessor, location.0.as_str(), segment.to_bytes()?)
+            .write_meta(self.data_accessor, location.0.as_str())
             .await?;
         Ok(location)
     }

--- a/src/query/storages/fuse/src/operations/commit.rs
+++ b/src/query/storages/fuse/src/operations/commit.rs
@@ -364,10 +364,7 @@ impl FuseTable {
             snapshot.table_statistics_location.is_some() && table_statistics.is_some();
 
         // 1. write down snapshot
-        let data = snapshot.to_bytes()?;
-        snapshot
-            .write_meta_data(operator, &snapshot_location, data)
-            .await?;
+        snapshot.write_meta(operator, &snapshot_location).await?;
         if need_to_save_statistics {
             table_statistics
                 .clone()

--- a/src/query/storages/fuse/src/operations/commit.rs
+++ b/src/query/storages/fuse/src/operations/commit.rs
@@ -359,7 +359,7 @@ impl FuseTable {
         operator: &Operator,
     ) -> Result<()> {
         let snapshot_location = location_generator
-            .snapshot_location_from_uuid(&snapshot.snapshot_id, snapshot.format_version())?;
+            .snapshot_location_from_uuid(&snapshot.snapshot_id, TableSnapshot::VERSION)?;
         let need_to_save_statistics =
             snapshot.table_statistics_location.is_some() && table_statistics.is_some();
 

--- a/src/query/storages/fuse/src/operations/navigate.rs
+++ b/src/query/storages/fuse/src/operations/navigate.rs
@@ -61,7 +61,6 @@ impl FuseTable {
         let snapshot_location = if let Some(loc) = self.snapshot_loc().await? {
             loc
         } else {
-            // not an error?
             return Err(ErrorCode::TableHistoricalDataNotFound(
                 "Empty Table has no historical data",
             ));

--- a/src/query/storages/fuse/src/operations/truncate.rs
+++ b/src/query/storages/fuse/src/operations/truncate.rs
@@ -33,11 +33,11 @@ impl FuseTable {
     pub async fn do_truncate(&self, ctx: Arc<dyn TableContext>, purge: bool) -> Result<()> {
         if let Some(prev_snapshot) = self.read_table_snapshot().await? {
             let prev_id = prev_snapshot.snapshot_id;
-
+            let prev_format_version = self.snapshot_format_version().await?;
             let new_snapshot = TableSnapshot::new(
                 Uuid::new_v4(),
                 &prev_snapshot.timestamp,
-                Some((prev_id, prev_snapshot.format_version())),
+                Some((prev_id, prev_format_version)),
                 prev_snapshot.schema.clone(),
                 Default::default(),
                 vec![],

--- a/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_blocks/fuse_block.rs
@@ -85,7 +85,7 @@ impl<'a> FuseBlock<'a> {
             );
 
             // find the element by snapshot_id in stream
-            while let Some(snapshot) = snapshot_stream.try_next().await? {
+            while let Some((snapshot, _)) = snapshot_stream.try_next().await? {
                 if snapshot.snapshot_id.simple().to_string() == self.snapshot_id.clone().unwrap() {
                     return self.to_block(snapshot).await;
                 }

--- a/src/query/storages/fuse/src/table_functions/fuse_segments/fuse_segment.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_segments/fuse_segment.rs
@@ -67,7 +67,7 @@ impl<'a> FuseSegment<'a> {
             );
 
             // find the element by snapshot_id in stream
-            while let Some(snapshot) = snapshot_stream.try_next().await? {
+            while let Some((snapshot, _)) = snapshot_stream.try_next().await? {
                 if snapshot.snapshot_id.simple().to_string() == self.snapshot_id {
                     return self.to_block(&snapshot.segments).await;
                 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- refactor: type safer meta write
  
   put the callings of different table meta serialization into `meta_writer.rs`
   `write_meta` no longer accepts all types that implement `serde::Serialization`
   
- fix flashback 

  besides fixing the problem,  removed method `Tablesnapshot::format_version()` which is misleading, 
  field `Tablesnapshot::format_version` is not supposed to be used that way

Closes #issue
